### PR TITLE
feat: add error cause when unwrap error

### DIFF
--- a/src/result/package.json
+++ b/src/result/package.json
@@ -12,6 +12,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "engines": {
+    "node": ">=16.9.x"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "prepublishOnly": "npm run build",

--- a/src/result/src/class/Err.class.ts
+++ b/src/result/src/class/Err.class.ts
@@ -26,7 +26,12 @@ export class ErrImpl<E> {
   }
 
   unwrap(): never {
-    throw new Error(`Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`);
+    const errorOptions = this.val instanceof Error ? { cause: this.val } : {};
+
+    throw new Error(
+      `Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`,
+      errorOptions
+    );
   }
 
   map(_mapper: unknown): ErrImpl<E> {

--- a/src/result/test/Result.spec.ts
+++ b/src/result/test/Result.spec.ts
@@ -90,6 +90,22 @@ describe("Err", () => {
         "oops"
       );
     });
+
+    it("should throw when unwraping an Err value and display the error cause (value is an Error)", () => {
+      class CustomError extends Error {
+        foo: string;
+
+        constructor(message: string) {
+          super(message);
+          this.foo = "bar";
+        }
+      }
+
+      assert.throws(
+        () => Err(new CustomError("oops")).unwrap(),
+        JSON.stringify({ foo: "bar" })
+      );
+    });
   });
 
   describe("unwrapOr", () => {


### PR DESCRIPTION
String(error) only displays error message. In case where Error come from of another CustomError, we lose other properties.